### PR TITLE
Build in RelWithDebInfo mode

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -19,14 +19,7 @@ if (($clean.IsPresent) -or (-not (Test-Path -Path "build")))
     $out = new-item -Path build -ItemType Directory
 }
 
-$buildType = "Debug"
-if ($release.IsPresent) {
-    $buildType = "RelWithDebInfo"
-}
+& cmake -G "Ninja" -DCMAKE_BUILD_TYPE="RelWithDebInfo" -B ./build .
+& cmake --build ./build
 
-cd build
-& cmake -G "Ninja" -DCMAKE_BUILD_TYPE="$buildType" ../
-& cmake --build .
-$ExitCode = $LastExitCode
-cd ..
 exit $ExitCode


### PR DESCRIPTION
This builds the binary in `RelWithDebInfo` mode at all times, which is better than always debug 
Also removes the `cd build` & `cd ..` so cancelling builds is no longer stupid